### PR TITLE
Add error handling for broken files; add PNG support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The first step to using this tool is to request & download a `Google Takeout`. A
 The tool takes in two parameters:
 
 1. an `inputDir` directory path containing the extracted Google Takeout.
+2. an `errorDir` directory path where images with bad EXIF data that fail to process will be moved to. The folder can be empty.
 
 This needs to be a single directory containing an _extracted_ zip from Google takeout. As described in the section above, it is important that the zip has been extracted into a directory (this tool doesn't extract zips for you) and that it is a single folder containing the whole Takeout (or if coming from multiple archives, that they have been properly merged together). 
 
@@ -118,6 +119,7 @@ This tool currently only extracts the following "media file" types. Any other fi
 - .jpg
 - .jpeg
 - .gif
+- .png
 - .mp4
 - .avi
 

--- a/README.md
+++ b/README.md
@@ -93,10 +93,11 @@ The first step to using this tool is to request & download a `Google Takeout`. A
 
 ## What inputs do I need to provide?
 
-The tool takes in two parameters:
+The tool takes in three parameters:
 
 1. an `inputDir` directory path containing the extracted Google Takeout.
-2. an `errorDir` directory path where images with bad EXIF data that fail to process will be moved to. The folder can be empty.
+2. an `outputDir` directory path where processed files will be moved to.
+3. an `errorDir` directory path where images with bad EXIF data that fail to process will be moved to. The folder can be empty.
 
 This needs to be a single directory containing an _extracted_ zip from Google takeout. As described in the section above, it is important that the zip has been extracted into a directory (this tool doesn't extract zips for you) and that it is a single folder containing the whole Takeout (or if coming from multiple archives, that they have been properly merged together). 
 

--- a/src/helpers/generate-unique-output-file-name.ts
+++ b/src/helpers/generate-unique-output-file-name.ts
@@ -1,7 +1,7 @@
 import { basename, extname } from 'path';
 
 /**
- * Given the name of a file that we want to copy to the output directory, generate a unique putput filename.
+ * Given the name of a file that we want to copy to the output directory, generate a unique output filename.
  * The function takes in the filename that we wish to copy and an array of all output files so far (all converted to lower case).
  *
  * If the filename doesn't already exist in the array, it just returns the original file name.

--- a/src/helpers/update-exif-metadata.ts
+++ b/src/helpers/update-exif-metadata.ts
@@ -1,17 +1,27 @@
 import { exiftool } from 'exiftool-vendored';
 import { doesFileSupportExif } from './does-file-support-exif';
 import { promises as fspromises } from 'fs';
+import { MediaFileInfo } from '../models/media-file-info';
+import { resolve } from 'path';
 
-const { unlink } = fspromises;
+const { unlink, copyFile } = fspromises;
 
-export async function updateExifMetadata(filePath: string, timeTaken: string): Promise<void> {
-  if (!doesFileSupportExif(filePath)) {
+export async function updateExifMetadata(fileInfo: MediaFileInfo, timeTaken: string, errorDir: string): Promise<void> {
+  if (!doesFileSupportExif(fileInfo.outputFilePath)) {
     return;
   }
 
-  await exiftool.write(filePath, {
-    DateTimeOriginal: timeTaken,
-  });
+  try {
+    await exiftool.write(fileInfo.outputFilePath, {
+      DateTimeOriginal: timeTaken,
+    });
+  
+    await unlink(`${fileInfo.outputFilePath}_original`); // exiftool will rename the old file to {filename}_original, we can delete that
 
-  await unlink(`${filePath}_original`); // exiftool will rename the old file to {filename}_original, we can delete that
+  } catch (error) {
+    await copyFile(fileInfo.outputFilePath,  resolve(errorDir, fileInfo.mediaFileName));
+    if (fileInfo.jsonFileExists && fileInfo.jsonFileName && fileInfo.jsonFilePath) {
+      await copyFile(fileInfo.jsonFilePath, resolve(errorDir, fileInfo.jsonFileName));
+    }
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,17 +18,17 @@ class GooglePhotosExif extends Command {
     version: flags.version({char: 'v'}),
     help: flags.help({char: 'h'}),
     inputDir: flags.string({
-      char: 's',
+      char: 'i',
       description: 'Directory containing the extracted contents of Google Photos Takeout zip file',
       required: true,
     }),
     outputDir: flags.string({
-      char: 'd',
+      char: 'o',
       description: 'Directory into which the processed output will be written',
       required: true,
     }),
     errorDir: flags.string({
-      char: 'd',
+      char: 'e',
       description: 'Directory for any files that have bad EXIF data - including the matching metadata files',
       required: true,
     }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,16 +27,21 @@ class GooglePhotosExif extends Command {
       description: 'Directory into which the processed output will be written',
       required: true,
     }),
+    errorDir: flags.string({
+      char: 'd',
+      description: 'Directory for any files that have bad EXIF data - including the matching metadata files',
+      required: true,
+    }),
   }
 
   static args: Parser.args.Input  = []
 
   async run() {
     const { args, flags} = this.parse(GooglePhotosExif);
-    const { inputDir, outputDir } = flags;
+    const { inputDir, outputDir, errorDir } = flags;
 
     try {
-      const directories = this.determineDirectoryPaths(inputDir, outputDir);
+      const directories = this.determineDirectoryPaths(inputDir, outputDir, errorDir);
       await this.prepareDirectories(directories);
       await this.processMediaFiles(directories);
     } catch (error) {
@@ -48,10 +53,11 @@ class GooglePhotosExif extends Command {
     this.exit(0);
   }
 
-  private determineDirectoryPaths(inputDir: string, outputDir: string): Directories {
+  private determineDirectoryPaths(inputDir: string, outputDir: string, errorDir: string): Directories {
     return {
       input: inputDir,
       output: outputDir,
+      error: errorDir
     };
   }
 
@@ -85,7 +91,8 @@ class GooglePhotosExif extends Command {
     const jpegs = mediaFiles.filter(mediaFile => mediaFile.mediaFileExtension.toLowerCase() === '.jpeg' || mediaFile.mediaFileExtension.toLowerCase() === '.jpg');
     const gifs = mediaFiles.filter(mediaFile => mediaFile.mediaFileExtension.toLowerCase() === '.gif');
     const mp4s = mediaFiles.filter(mediaFile => mediaFile.mediaFileExtension.toLowerCase() === '.mp4');
-    this.log(`--- Found ${jpegs.length} JPEGs, ${gifs.length} GIFs and ${mp4s.length} MP4s ---`);
+    const pngs = mediaFiles.filter(mediaFile => mediaFile.mediaFileExtension.toLowerCase() === '.png');
+    this.log(`--- Found ${jpegs.length} JPEGs, ${gifs.length} GIFs, ${pngs.length} PNGs, and ${mp4s.length} MP4s ---`);
 
     this.log(`--- Processing media files ---`);
     const fileNamesWithEditedExif: string[] = [];
@@ -103,7 +110,7 @@ class GooglePhotosExif extends Command {
         if (mediaFile.supportsExif) {
           const hasExifDate = await doesFileHaveExifDate(mediaFile.mediaFilePath);
           if (!hasExifDate) {
-            await updateExifMetadata(mediaFile.outputFilePath, photoTimeTaken);
+            await updateExifMetadata(mediaFile, photoTimeTaken, directories.error);
             fileNamesWithEditedExif.push(mediaFile.outputFileName);
             this.log(`Wrote "DateTimeOriginal" EXIF metadata to: ${mediaFile.outputFileName}`);
           }
@@ -114,7 +121,7 @@ class GooglePhotosExif extends Command {
     }
 
     // Log a summary
-    this.log(`--- Processed ${mediaFiles.length} media files (${jpegs.length} JPEGs, ${gifs.length} GIFs and ${mp4s.length} MP4s) ---`);
+    this.log(`--- Processed ${mediaFiles.length} media files (${jpegs.length} JPEGs, ${gifs.length} GIFs, ${pngs.length} PNGs, and ${mp4s.length} MP4s) ---`);
     this.log(`--- The file modified timestamp has been updated on all media files ---`)
     if (fileNamesWithEditedExif.length > 0) {
       this.log(`--- Found ${fileNamesWithEditedExif.length} files which support EXIF, but had no DateTimeOriginal field. For each of the following files, the DateTimeOriginalField has been updated using the date found in the JSON metadata: ---`);

--- a/src/models/directories.ts
+++ b/src/models/directories.ts
@@ -1,4 +1,5 @@
 export interface Directories {
   input: string;
   output: string;
+  error: string;
 }

--- a/src/models/supported-media-file-extensions.ts
+++ b/src/models/supported-media-file-extensions.ts
@@ -1,1 +1,1 @@
-export const SUPPORTED_MEDIA_FILE_EXTENSIONS = ['.jpeg', '.jpg', '.gif', '.mp4'];
+export const SUPPORTED_MEDIA_FILE_EXTENSIONS = ['.jpeg', '.jpg', '.gif', '.mp4', '.png'];


### PR DESCRIPTION
I ran into this: https://github.com/mattwilson1024/google-photos-exif/issues/3

Out of around 50,000 pictures, I ended up with around a dozen that exiftool couldn't handle. The issue is that the processing crashes and you have to clear the output directory after fixing each file. This PR adds an error directory to copy any bad images (and the metadata files) to be fixed and re-processed later. This way, you can process an entire directory, despite any errors.

The following helped to clean-up any bad files: `exiftool -all= -tagsfromfile @ -all:all -unsafe -icc_profile "D:\BROKEN\file.jpg"`
exiftool is pretty good about giving you helpful output - most of the 'bad' files had an incorrect file extension (JPG should be PNG)