### PR TITLE
Add support for AVI videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ This tool currently only extracts the following "media file" types. Any other fi
 - .jpeg
 - .gif
 - .mp4
+- .avi
 
 ## What does the tool do?
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,8 @@ class GooglePhotosExif extends Command {
     const jpegs = mediaFiles.filter(mediaFile => mediaFile.mediaFileExtension.toLowerCase() === '.jpeg' || mediaFile.mediaFileExtension.toLowerCase() === '.jpg');
     const gifs = mediaFiles.filter(mediaFile => mediaFile.mediaFileExtension.toLowerCase() === '.gif');
     const mp4s = mediaFiles.filter(mediaFile => mediaFile.mediaFileExtension.toLowerCase() === '.mp4');
-    this.log(`--- Found ${jpegs.length} JPEGs, ${gifs.length} GIFs and ${mp4s.length} MP4s ---`);
+    const avis = mediaFiles.filter(mediaFile => mediaFile.mediaFileExtension.toLowerCase() === '.avi');
+    this.log(`--- Found ${jpegs.length} JPEGs, ${gifs.length} GIFs and ${mp4s.length} MP4s and ${avis.length} AVIs ---`);
 
     this.log(`--- Processing media files ---`);
     const fileNamesWithEditedExif: string[] = [];
@@ -114,7 +115,7 @@ class GooglePhotosExif extends Command {
     }
 
     // Log a summary
-    this.log(`--- Processed ${mediaFiles.length} media files (${jpegs.length} JPEGs, ${gifs.length} GIFs and ${mp4s.length} MP4s) ---`);
+    this.log(`--- Processed ${mediaFiles.length} media files (${jpegs.length} JPEGs, ${gifs.length} GIFs and ${mp4s.length} MP4s and ${avis.length} AVIs) ---`);
     this.log(`--- The file modified timestamp has been updated on all media files ---`)
     if (fileNamesWithEditedExif.length > 0) {
       this.log(`--- Found ${fileNamesWithEditedExif.length} files which support EXIF, but had no DateTimeOriginal field. For each of the following files, the DateTimeOriginalField has been updated using the date found in the JSON metadata: ---`);

--- a/src/models/supported-media-file-extensions.ts
+++ b/src/models/supported-media-file-extensions.ts
@@ -1,1 +1,1 @@
-export const SUPPORTED_MEDIA_FILE_EXTENSIONS = ['.jpeg', '.jpg', '.gif', '.mp4'];
+export const SUPPORTED_MEDIA_FILE_EXTENSIONS = ['.jpeg', '.jpg', '.gif', '.mp4', '.avi'];


### PR DESCRIPTION
Hi there,

I'm very glad I found your project but since I had a bunch of AVI files I didn't really understand why you were hardcoding only `mp4` as a support video filename since there's nothing really preventing the original creation date from being applied to these files as well.

The process worked fine for me. Here's the output after I modified the `SUPPORTED_MEDIA_FILE_EXTENSIONS` constant to temporarily only list `['.mp4']` (might be a neat feature, filter by only specific types):

```
$ yarn start --inputDir /Volumes/Monolith/Takeout/Google\ Photos/ --outputDir /Volumes/Monolith/Takeout/Clean/
yarn run v1.22.10
$ ./bin/run --inputDir '/Volumes/Monolith/Takeout/Google Photos/' --outputDir /Volumes/Monolith/Takeout/Clean/
--- Finding supported media files (.avi) ---
--- Found 0 JPEGs, 0 GIFs and 0 MP4s and 55 AVIs ---
--- Processing media files ---
Copying file 0 of 55: /Volumes/Monolith/Takeout/Google Photos/20070801/SNC10339.AVI -> SNC10339.AVI
Copying file 1 of 55: /Volumes/Monolith/Takeout/Google Photos/20070802/SNC10342.AVI -> SNC10342.AVI
Copying file 2 of 55: /Volumes/Monolith/Takeout/Google Photos/20070812/SNC10360-1.AVI -> SNC10360-1.AVI
Copying file 3 of 55: /Volumes/Monolith/Takeout/Google Photos/20080823/SNC10386.AVI -> SNC10386.AVI
...
Copying file 53 of 55: /Volumes/Monolith/Takeout/Google Photos/Trash/MVI_0231.avi -> MVI_0231.avi
Copying file 54 of 55: /Volumes/Monolith/Takeout/Google Photos/Trash/MVI_0232.avi -> MVI_0232.avi
--- Processed 55 media files (0 JPEGs, 0 GIFs and 0 MP4s and 55 AVIs) ---
--- The file modified timestamp has been updated on all media files ---
--- We did not edit EXIF metadata for any of the files. This could be because all files already had a value set for the DateTimeOriginal field, or because we did not have a corresponding JSON file. ---
Done 🎉
✨  Done in 10.05s.
```

The output files were correct as well: 

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/65950/109756820-9e98a400-7bb6-11eb-8c50-dcb48ec7924c.png">
