### PR TITLE
Allow easy configuration of supported file types and add support for HEIC+MOV

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,21 +110,33 @@ Takeout
     ...
 ```
 
-## Supported file types
+## Configuring supported file types
 
-This tool currently only extracts the following "media file" types. Any other files will be ignored and not included in the output:
-- .jpg
-- .jpeg
-- .gif
-- .png
-- .mp4
-- .avi
+In order to avoid touching files that are not photos or videos, this tool will only process files whose extensions are whitelisted in the configuration options. Any other files will be ignored and not included in the output.
+
+To customise which files are processed, edit the `src/config.ts` file to suit your needs. For each extension you can also configure whether or not to attempt to read/write EXIF metadata for that file type.
+
+The default configuration is as follows:
+```
+┌──────────┬─────────┐
+│Extension │EXIF     │
+├──────────┼─────────┤
+│.jpeg     │true     │
+│.jpg      │true     │
+│.heic     │true     │
+│.gif      │false    │
+│.mp4      │false    │
+│.png      │false    │
+│.avi      │false    │
+│.mov      │false    │
+└──────────┴─────────┘
+```
 
 ## What does the tool do?
 
 The tool will do the following:
-1. Find all "media files" with one of the supported extensions listed above from the (nested) `inputDir` folder structure.
-
+1. Find all "media files" with one of the supported extensions (see "Configuring supported file types" above) from the (nested) `inputDir` folder structure.
+  
 2. For each "media file":
    
    a. Look for a corresponding sidecar JSON metadata file (see the section below for more on this) and if found, read the `photoTakenTime` field

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,14 @@
+import { Config } from './models/config-models';
+
+export const CONFIG: Config = {
+  supportedMediaFileTypes: [
+    { extension: '.jpeg', supportsExif: true },
+    { extension: '.jpg',  supportsExif: true },
+    { extension: '.heic', supportsExif: true },
+    { extension: '.gif',  supportsExif: false },
+    { extension: '.mp4',  supportsExif: false },
+    { extension: '.png',  supportsExif: false },
+    { extension: '.avi',  supportsExif: false },
+    { extension: '.mov',  supportsExif: false },
+  ],
+};

--- a/src/helpers/does-file-support-exif.ts
+++ b/src/helpers/does-file-support-exif.ts
@@ -1,6 +1,8 @@
 import { extname } from 'path';
+import { CONFIG } from '../config';
 
 export function doesFileSupportExif(filePath: string): boolean {
   const extension = extname(filePath);
-  return extension.toLowerCase() === '.jpeg' || extension.toLowerCase() === '.jpg';
+  const mediaFileType = CONFIG.supportedMediaFileTypes.find(fileType => fileType.extension.toLowerCase() === extension.toLowerCase());
+  return mediaFileType?.supportsExif ?? false;
 }

--- a/src/helpers/find-files-with-extension-recursively.ts
+++ b/src/helpers/find-files-with-extension-recursively.ts
@@ -1,5 +1,5 @@
-import { getAllFilesRecursively } from './get-all-files-recursively';
 import { extname } from 'path';
+import { getAllFilesRecursively } from './get-all-files-recursively';
 
 export async function findFilesWithExtensionRecursively(dirToSearch: string, extensionsToInclude: string[]): Promise<string[]> {
   const allFiles = await getAllFilesRecursively(dirToSearch);
@@ -10,7 +10,7 @@ export async function findFilesWithExtensionRecursively(dirToSearch: string, ext
 
   const matchingFiles = allFiles.filter(filePath => {
     const extension = extname(filePath).toLowerCase();
-    return extensionsToInclude.map(ext => ext.toLowerCase()).includes(extension);
+    return extensionsToInclude.map(ext => ext.toLowerCase()).includes(extension.toLowerCase());
   });
   return matchingFiles;
 }

--- a/src/helpers/find-supported-media-files.ts
+++ b/src/helpers/find-supported-media-files.ts
@@ -1,14 +1,15 @@
 import { existsSync } from 'fs';
 import { basename, extname, resolve } from 'path';
+import { CONFIG } from '../config';
 import { MediaFileInfo } from '../models/media-file-info';
-import { SUPPORTED_MEDIA_FILE_EXTENSIONS } from '../models/supported-media-file-extensions';
 import { doesFileSupportExif } from './does-file-support-exif';
 import { findFilesWithExtensionRecursively } from './find-files-with-extension-recursively';
 import { generateUniqueOutputFileName } from './generate-unique-output-file-name';
 import { getCompanionJsonPathForMediaFile } from './get-companion-json-path-for-media-file';
 
 export async function findSupportedMediaFiles(inputDir: string, outputDir: string): Promise<MediaFileInfo[]> {
-  const mediaFilePaths = await findFilesWithExtensionRecursively(inputDir, SUPPORTED_MEDIA_FILE_EXTENSIONS);
+  const supportedMediaFileExtensions = CONFIG.supportedMediaFileTypes.map(fileType => fileType.extension);
+  const mediaFilePaths = await findFilesWithExtensionRecursively(inputDir, supportedMediaFileExtensions);
 
   const mediaFiles: MediaFileInfo[] = [];
   const allUsedOutputFilesLowerCased: string[] = [];

--- a/src/models/config-models.ts
+++ b/src/models/config-models.ts
@@ -1,0 +1,8 @@
+export interface Config {
+  supportedMediaFileTypes: IMediaFileType[];
+}
+
+export interface IMediaFileType {
+  extension: string;
+  supportsExif: boolean;
+}

--- a/src/models/supported-media-file-extensions.ts
+++ b/src/models/supported-media-file-extensions.ts
@@ -1,1 +1,0 @@
-export const SUPPORTED_MEDIA_FILE_EXTENSIONS = ['.jpeg', '.jpg', '.gif', '.mp4', '.png', '.avi'];


### PR DESCRIPTION
Closes #22

This PR adds support for HEIC+MOV formats commonly generated by Apple devices such as iPhones.

It also adds a `config.ts` file which makes it easy to customise which file formats are processed by the tool and which ones we should attempt to read+write EXIF metadata for.