### PR TITLE
Added functionality to exclude partner sharing files with flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The tool takes in three parameters:
 1. an `inputDir` directory path containing the extracted Google Takeout.
 2. an `outputDir` directory path where processed files will be moved to. This needs to be an empty directory and can be anywhere on the disk. 
 3. an `errorDir` directory path where images with bad EXIF data that fail to process will be moved to. The folder can be empty.
+4. an `excludePartnerSharingMedia` flag (optional). This flag causes any media that was saved via Google Partner Sharing to be skipped.
 
 The `inputDir` needs to be a single directory containing an _extracted_ zip from Google takeout. As described in the section above, it is important that the zip has been extracted into a directory (this tool doesn't extract zips for you) and that it is a single folder containing the whole Takeout (or if coming from multiple archives, that they have been properly merged together). 
 
@@ -108,6 +109,11 @@ Takeout
     2017-04-03
     2020-01-01
     ...
+```
+
+Example use of `excludePartnerSharingMedia` flag:
+```
+yarn start --inputDir ~/takeout --outputDir ~/output --errorDir ~/error --excludePartnerSharingMedia
 ```
 
 ## Configuring supported file types

--- a/src/helpers/is-from-google-partner-sharing.ts
+++ b/src/helpers/is-from-google-partner-sharing.ts
@@ -1,0 +1,20 @@
+import { GoogleMetadata } from "../models/google-metadata"; 
+import { promises as fspromises } from "fs"
+import { MediaFileInfo } from '../models/media-file-info'
+
+const { readFile } = fspromises;
+
+export async function isFromGooglePartnerSharing(mediaFile: MediaFileInfo): Promise<boolean> {
+  if (!mediaFile.jsonFilePath || !mediaFile.jsonFileExists) {
+    return false;
+  }
+
+  const jsonContents = await readFile(mediaFile.jsonFilePath, 'utf8');
+  const googleJsonMetadata = JSON.parse(jsonContents) as GoogleMetadata;
+
+  if (googleJsonMetadata?.googlePhotosOrigin?.fromPartnerSharing) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/src/models/google-metadata.ts
+++ b/src/models/google-metadata.ts
@@ -28,4 +28,5 @@ interface GooglePhotosOrigin {
   mobileUpload: object;
   fromPartnerSharing: object;
   driveSync: object;
+  driveDesktopUploader: object;
 }

--- a/src/models/google-metadata.ts
+++ b/src/models/google-metadata.ts
@@ -8,6 +8,7 @@ export interface GoogleMetadata {
   geoDataExif: GeoData;
   photoTakenTime: GoogleTimestamp;
   favorited: boolean;
+  googlePhotosOrigin: GooglePhotosOrigin;
 }
 
 interface GeoData {
@@ -21,4 +22,10 @@ interface GeoData {
 interface GoogleTimestamp {
   timestamp: string;
   formatted: string;
+}
+
+interface GooglePhotosOrigin {
+  mobileUpload: object;
+  fromPartnerSharing: object;
+  driveSync: object;
 }


### PR DESCRIPTION
added --excludePartnerSharingMedia flag to the command so that you have the ability to skip media that has the "fromPartnerSharing" object in the "googlePhotosOrigin" object in the sidecar JSON.