### PR TITLE
Add 2 new rules for companion JSON files

### DIFF
--- a/src/helpers/get-companion-json-path-for-media-file.ts
+++ b/src/helpers/get-companion-json-path-for-media-file.ts
@@ -17,6 +17,12 @@ export function getCompanionJsonPathForMediaFile(mediaFilePath: string): string|
   const potentialJsonFileNames: string[] = [
     `${mediaFileNameWithoutExtension}.json`,
     `${mediaFileNameWithoutExtension}${mediaFileExtension}.json`,
+     // Some files have a xyz.mp4, xyz.jpg and xyz.jpg.json. The mp4 doesn't have its own.
+     // So xyz.mp4 should become xyz.jpg.json
+    `${mediaFileNameWithoutExtension}.jpg.json`,
+     // If the filename is more than 46 characters, Google can trim it to 46 characters.
+     // So xyz.jpg becomes xy.json
+    `${mediaFileNameWithoutExtension.substring(0,46)}.json`
   ];
 
   // Another edge case which seems to be quite inconsistent occurs when we have media files containing a number suffix for example "foo(1).jpg"
@@ -54,5 +60,6 @@ export function getCompanionJsonPathForMediaFile(mediaFilePath: string): string|
 
   // If no JSON file was found, just return null - we won't be able to adjust the date timestamps without finding a
   // suitable JSON sidecar file
+  console.log(`Missing JSON for ${mediaFilePath}`)
   return null;
 }

--- a/src/helpers/get-companion-json-path-for-media-file.ts
+++ b/src/helpers/get-companion-json-path-for-media-file.ts
@@ -60,6 +60,5 @@ export function getCompanionJsonPathForMediaFile(mediaFilePath: string): string|
 
   // If no JSON file was found, just return null - we won't be able to adjust the date timestamps without finding a
   // suitable JSON sidecar file
-  console.log(`Missing JSON for ${mediaFilePath}`)
   return null;
 }


### PR DESCRIPTION
Firstly I just want to say a massive thank you for this amazing project. I’ve just been migrating about 100GB of media from google to iCloud and this has been invaluable.

I had to add a couple of rules for finding the companion JSON file for my use case:

1. Some images/videos (I think they are some kind of multi-shot image) have 3 linked files
  - foo_MP.jpg
  - foo_MP.mp4
  - foo_MP.jpg.json
So the video needs to use the .jpg.json file.

2. Some image names seemed to be cut off after 46 characters, so I would get
  - long_string_ab.json
  - long_string_abc.jpg

With these two added rules, I didn’t get any files missing sidecar JSONs

Feel free to merge if it will be useful.

Thanks again for the awesome project, it saved me so much time!