### PR TITLE
Preserve subfolders in output directory

### DIFF
--- a/src/models/media-file-info.ts
+++ b/src/models/media-file-info.ts
@@ -10,4 +10,5 @@ export interface MediaFileInfo {
 
   outputFileName: string;
   outputFilePath: string;
+  outputFileFolder: string;
 }


### PR DESCRIPTION
Thank you so much for this tool - helped me solve this problem in a day rather than a week!

I happened to have a complex folder structure in my source directory and wanted it preserving in the destination directory.  This PR adds a flag to detect and preserve the intermediate folders.